### PR TITLE
Update LensesApp.csproj

### DIFF
--- a/dotnet/LensesApp.csproj
+++ b/dotnet/LensesApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
training on cosmosdb on azure will no longer work with dotnet 2.1, updating csproj so that it works with dotnet core 3.1