### PR TITLE
Update LensesApp.csproj

### DIFF
--- a/dotnet/LensesApp.csproj
+++ b/dotnet/LensesApp.csproj
@@ -8,6 +8,7 @@
   <ItemGroup>
     <None Update="appsettings.json" CopyToOutputDirectory="PreserveNewest" />
     <PackageReference Include="Microsoft.Azure.Cosmos.Table" Version="1.0" />
+    <PackageReference Include="Microsoft.Azure.KeyVault.Core" Version="3.0.5" />
     <PackageReference Include="Microsoft.Azure.Storage.Common" Version="9.4.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="2.2.0" />


### PR DESCRIPTION
adding a reference to updated Microsoft.Azure.KeyVault.Core to avoid warnings in compilation on dotnet 3.1